### PR TITLE
Adjust leadership calculations for director roles

### DIFF
--- a/черновик.html
+++ b/черновик.html
@@ -278,6 +278,7 @@ html, body { background-clip: border-box; }
             <option>РУ</option>
             <option>РМ</option>
             <option>Директор</option>
+            <option>ТУ</option>
             <option>Зам.Директора</option>
             <option>Зам. Директора по направлению Кафе</option>
             <option>Зам. Директора по направлению розницы</option>
@@ -484,6 +485,12 @@ html, body { background-clip: border-box; }
       'Заведующий кондитерским и пекарским производством','Заведующий цехом','Начальник цеха',
       'Руководитель мясного производства','Руководитель хлебопекарного производства','Начальник мясного цеха'
     ];
+    const DIRECTOR_ROLES_WITH_TEAM = ['Директор','ТУ'];
+    const DEPUTY_ROLES = [
+      'Зам.Директора',
+      'Зам. Директора по направлению Кафе',
+      'Зам. Директора по направлению розницы',
+    ];
     function addFCRolesIfNeeded(){
       const selRole = document.getElementById('role');
       const bu = document.getElementById('bu').value;
@@ -677,6 +684,41 @@ html, body { background-clip: border-box; }
           });
           breakdown.context = 'Формула для производственных ролей ФК';
         }
+      } else if(DIRECTOR_ROLES_WITH_TEAM.includes(role)){
+        const teamRaw = num($('#teamIndex').value);
+        const teamScore = Number.isFinite(teamRaw) ? teamRaw : 0;
+        const teamValue = Number.isFinite(teamRaw) ? fmtValue(teamRaw) : '— (использовано 0)';
+        addMetric({
+          label:'Балл (индекс команды)',
+          valueDisplay: teamValue,
+          score: teamScore,
+          scale: SCALE_TEXT.teamIndex,
+          note: Number.isFinite(teamRaw) ? '' : 'Поле пустое — в расчёте используется 0.',
+        });
+
+        const mid = (axScore + assessScore) / 2;
+        baseTotal = (mid + hrScore + teamScore) / 3;
+        breakdown.steps.push({
+          label:'Среднее по Аксиологии и Ассессменту',
+          formula:`(${fmtScore(axScore)} + ${fmtScore(assessScore)}) / 2 = ${fmt(mid)}`,
+        });
+        breakdown.steps.push({
+          label:'Итог без штрафов',
+          formula:`(${fmt(mid)} + ${fmtScore(hrScore)} + ${fmtScore(teamScore)}) / 3 = ${fmt(baseTotal)}`,
+        });
+        breakdown.context = 'Формула для должностей «Директор» и «ТУ»';
+      } else if(DEPUTY_ROLES.includes(role)){
+        const mid = (axScore + assessScore) / 2;
+        baseTotal = (mid + hrScore) / 2;
+        breakdown.steps.push({
+          label:'Среднее по Аксиологии и Ассессменту',
+          formula:`(${fmtScore(axScore)} + ${fmtScore(assessScore)}) / 2 = ${fmt(mid)}`,
+        });
+        breakdown.steps.push({
+          label:'Итог без штрафов',
+          formula:`(${fmt(mid)} + ${fmtScore(hrScore)}) / 2 = ${fmt(baseTotal)}`,
+        });
+        breakdown.context = 'Формула для заместителей директора';
       } else {
         baseTotal = (axScore + hrScore + assessScore) / 3;
         breakdown.steps.push({
@@ -707,10 +749,16 @@ html, body { background-clip: border-box; }
       breakdown.penaltyFormula = penaltyItems.length
         ? penaltyItems.map(p=>`${fmtMult(p.count)}×${fmtMult(p.weight)}`).join(' + ')
         : '0';
-      breakdown.prePenalty = baseTotal;
-      breakdown.final = baseTotal - penalty;
 
-      return {score: baseTotal - penalty, penalty, breakdown};
+      const rawFinal = baseTotal - penalty;
+      const finalScore = Math.max(rawFinal, 0);
+
+      breakdown.prePenalty = baseTotal;
+      breakdown.finalRaw = rawFinal;
+      breakdown.final = finalScore;
+      breakdown.finalCapped = Number.isFinite(rawFinal) && rawFinal < 0;
+
+      return {score: finalScore, penalty, breakdown};
     }
 
     // ===== Кластеры =====
@@ -797,7 +845,7 @@ html, body { background-clip: border-box; }
 
     function classifyByRole(role, bizScore, leadScore){
       const group1 = ['ОД','РУ','РМ'];
-      const group2 = ['Директор','Зам.Директора','Зам. Директора по направлению Кафе','Зам. Директора по направлению розницы'];
+      const group2 = [...DIRECTOR_ROLES_WITH_TEAM, ...DEPUTY_ROLES];
       if(group1.includes(role)){
         return buildClassificationResult(CLASSIFICATION_RULES.group1, bizScore, leadScore);
       }
@@ -854,8 +902,16 @@ html, body { background-clip: border-box; }
         html += `<p class="calc-formula">${step.label}: ${step.formula}</p>`;
       });
       if(Number.isFinite(data?.prePenalty) && Number.isFinite(data?.penalty) && Number.isFinite(data?.final)){
-        html += `<p class="calc-formula">Итог лидерства = ${fmt(data.prePenalty)} − ${fmt(data.penalty)} = ${fmt(data.final)}</p>`;
+        const isCapped = Boolean(data?.finalCapped);
+        const baseFormula = isCapped
+          ? `max(0, ${fmt(data.prePenalty)} − ${fmt(data.penalty)})`
+          : `${fmt(data.prePenalty)} − ${fmt(data.penalty)}`;
+        html += `<p class="calc-formula">Итог лидерства = ${baseFormula} = ${fmt(data.final)}</p>`;
         html += '<p class="calc-note">Из итоговой оценки вычитаются штрафы за нарушения.</p>';
+        if(isCapped){
+          const rawText = Number.isFinite(data?.finalRaw) ? ` (без ограничения получилось ${fmt(data.finalRaw)})` : '';
+          html += `<p class="calc-note">Значение не может быть меньше 0, поэтому итоговое лидерство установлено в 0${rawText}.</p>`;
+        }
       }
       el.innerHTML = html;
     }
@@ -955,7 +1011,8 @@ html, body { background-clip: border-box; }
       }
       $('#prodWrap').style.display = (bu==='ФК' && FC_ROLES.includes(role)) ? '' : 'none';
       $('#budgetWrap').style.display = (bu==='ФК' && role==='Директор Производства') ? '' : 'none';
-      $('#teamIndexWrap').style.display = (bu==='ФК' && role==='Директор Производства') ? '' : 'none';
+      const showTeamIndex = (bu==='ФК' && role==='Директор Производства') || DIRECTOR_ROLES_WITH_TEAM.includes(role);
+      $('#teamIndexWrap').style.display = showTeamIndex ? '' : 'none';
     }
 
     // ===== Значения нарушений по умолчанию =====


### PR DESCRIPTION
## Summary
- add the ТУ role to the position selector and leadership classification rules
- update leadership index formulas for директор, ТУ and deputy positions, including use of the team index field
- show the team index input when it is required by the selected role
- prevent leadership scores from dropping below zero and explain the cap in the breakdown output

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d3ec081bf883308ce975b948d62709