### PR TITLE
Add dynamic iframe height synchronization to parent window

### DIFF
--- a/index.html
+++ b/index.html
@@ -1615,5 +1615,20 @@ $('#lbl-t2').textContent = (bu === 'ФК' && FC_ROLES.includes(role)) ? '% Не�
   }catch(e){}
 })();
 </script>
+<script>
+  // Функция, которая измеряет высоту и отправляет ее родительскому окну
+  function sendHeightToParent() {
+    const height = document.documentElement.scrollHeight;
+    // Отправляем сообщение наверх
+    window.parent.postMessage({ frameHeight: height }, '*');
+  }
+
+  // Отправляем высоту при первой загрузке страницы
+  window.addEventListener('load', sendHeightToParent);
+
+  // Используем ResizeObserver, чтобы следить за изменениями (например, когда открываются новые поля)
+  const observer = new ResizeObserver(sendHeightToParent);
+  observer.observe(document.body);
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
Added functionality to dynamically measure and communicate the iframe's content height to its parent window, enabling responsive iframe resizing based on content changes.

## Key Changes
- Implemented `sendHeightToParent()` function that measures the document's scroll height and sends it to the parent window via `postMessage` API
- Added load event listener to send initial height measurement when the page first loads
- Integrated `ResizeObserver` to continuously monitor the document body for size changes and automatically update the parent window when content dimensions change (e.g., when form fields expand or collapse)

## Implementation Details
- Uses `document.documentElement.scrollHeight` to accurately measure total content height
- Communicates via `window.parent.postMessage()` with wildcard origin (`'*'`) for flexibility
- Employs `ResizeObserver` for efficient, event-driven height updates rather than polling
- Ensures height is sent both on initial page load and whenever dynamic content changes occur

https://claude.ai/code/session_01N1XgSWWEiGd9DMvoCXniuv