### PR TITLE
Refresh calculator UI, fix dark theme and optimize for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,9 +7,22 @@
   <title>Калькулятор эффективности и лидерства — Neo</title>
   <style>
   /* Когда страница во фрейме — убираем крупную «шапку»
-   и добавляем отступ снизу, чтобы кнопку Bitrix не накрывало */
-.is-embed .site-header { display:none; }
-.is-embed .container { padding-bottom: 100px; }
+   и добавляем отступ снизу, чтобы кнопку Bitrix не накрывало.
+   Но оставляем плавающую кнопку переключения темы в правом верхнем углу. */
+.is-embed .site-header{
+  position:fixed; top:10px; right:10px; left:auto;
+  z-index:120; padding:0; pointer-events:none;
+}
+.is-embed .header-inner{
+  padding:0; margin:0; display:block; pointer-events:auto;
+  max-width:none;
+}
+.is-embed .brand{display:none}
+.is-embed .theme-toggle{
+  box-shadow:0 10px 28px rgba(2,6,23,.35), 0 0 0 1px var(--border);
+  backdrop-filter:saturate(140%) blur(10px);
+}
+.is-embed .container{ padding-top: 8px; padding-bottom: 120px; }
 
 /* На всякий: прозрачный фон, чтобы не было белых «полей» вокруг */
 html, body { background-clip: border-box; }
@@ -273,12 +286,82 @@ html, body { background-clip: border-box; }
     .table-scroll{overflow-x:auto; -webkit-overflow-scrolling:touch}
     .table-scroll table{min-width:620px}
 
-    @media (max-width: 640px){
-      .btns{position:sticky; bottom:0; background:linear-gradient(180deg, rgba(10,12,20,.70), rgba(10,12,20,.94)); backdrop-filter:blur(10px) saturate(140%); padding:12px; border-top:1px solid var(--border); z-index:20}
-      :root[data-theme="light"] .btns{background:linear-gradient(180deg, rgba(255,255,255,.80), rgba(255,255,255,.96));}
-      .section.is-collapsible summary{cursor:pointer; list-style:none; display:flex; align-items:center; gap:8px; font-weight:800; padding:10px 0; color:var(--text-strong)}
+    /* ===== Мобильная адаптация ===== */
+    @media (max-width: 860px){
+      .header-inner{padding:16px 14px 10px}
+      .brand-title{font-size:17px}
+      .brand-sub{font-size:11px}
+      .container{margin:10px auto 40px; padding:0 12px}
+      .card{padding:16px 14px; border-radius:16px}
+      h1{font-size:22px; line-height:1.25}
+      p.sub{font-size:13px; margin-bottom:14px}
+
+      /* Поля становятся на отдельную строку — метка сверху, инпут на всю ширину */
+      .kpi{grid-template-columns:1fr; gap:6px; margin-top:10px}
+      .kpi label{margin:8px 0 4px}
+      .row{grid-template-columns:1fr; gap:6px}
+
+      /* iOS не должен зумить при фокусе на инпуте — минимум 16px */
+      input[type="number"], .csel-btn{font-size:16px; padding:14px 14px; border-radius:12px}
+
+      /* Секция-заголовок крупнее и чётче */
+      .section h3, .section h4{font-size:16px}
+
+      /* Результаты — одна колонка, цифры компактнее */
+      .result{grid-template-columns:1fr; gap:10px}
+      .stat{padding:14px}
+      .stat .val{font-size:26px}
+
+      /* Карточки расчётов — одна колонка */
+      .calc-grid{grid-template-columns:1fr}
+      .calc-card{padding:14px}
+      .calc-card h5{font-size:15px}
+      .calc-formula{font-size:11px; padding:9px 10px}
+
+      /* Тема-тоггл: чуть крупнее для удобного тапа */
+      .theme-toggle{width:46px; height:46px}
+
+      /* Липкая панель кнопок — на всю ширину, удобный тап */
+      .btns{
+        position:sticky; bottom:0;
+        margin:18px -14px -16px;
+        padding:12px 14px calc(12px + env(safe-area-inset-bottom));
+        background:linear-gradient(180deg, rgba(10,12,20,.70), rgba(10,12,20,.94));
+        backdrop-filter:blur(10px) saturate(140%);
+        border-top:1px solid var(--border); z-index:20;
+        display:flex; gap:10px;
+      }
+      :root[data-theme="light"] .btns{background:linear-gradient(180deg, rgba(255,255,255,.82), rgba(255,255,255,.97));}
+      .btns button{flex:1 1 auto; padding:14px 16px; font-size:15px}
+      .btns .ghost{flex:0 1 auto}
+      .btns #formError{flex:1 1 100%; order:-1; margin:0 0 4px}
+
+      /* Сворачиваемые секции */
+      .section.is-collapsible summary{cursor:pointer; list-style:none; display:flex; align-items:center; gap:8px; font-weight:800; padding:12px 0; color:var(--text-strong); font-size:15px}
       .section.is-collapsible summary::-webkit-details-marker{display:none}
-      .section.is-collapsible{border-top:none; margin-top:12px; padding-top:0}
+      .section.is-collapsible summary::after{
+        content:"▾"; margin-left:auto; color:var(--muted);
+        transition:transform .15s ease;
+      }
+      .section.is-collapsible[open] summary::after{transform:rotate(180deg)}
+      .section.is-collapsible{border-top:1px dashed var(--border); margin-top:14px; padding-top:4px}
+
+      /* Таблица нарушений — комфортная ширина инпутов */
+      #violations-wrap table{min-width:560px}
+      #violations-wrap td input[type="number"]{padding:10px 12px; font-size:15px}
+
+      /* Кастомный селект — панель на всю ширину поля */
+      .csel-panel{max-height:50vh}
+      .csel-option{padding:14px 14px; font-size:15px}
+    }
+
+    @media (max-width: 420px){
+      h1{font-size:20px}
+      .brand-mark{width:38px;height:38px;border-radius:12px}
+      .brand-title{font-size:16px}
+      .stat .val{font-size:22px}
+      .theme-toggle{width:42px;height:42px;font-size:16px}
+      .card{padding:14px 12px}
     }
 
     .kpi-hint{font-size:12px; color:var(--muted); margin-top:6px}


### PR DESCRIPTION
## Summary

Полный визуальный рефреш калькулятора без изменения логики расчётов. Исправлена читаемость на тёмной теме и добавлена адаптация под мобильные устройства.

### Тёмная тема / читаемость
- Переработаны цветовые токены: более контрастные `--text`, `--muted`, добавлены `--text-strong` и `--card-2`.
- Инпуты, селекты, stat-карточки и карточки расчётов получили сплошные фоны вместо полупрозрачных градиентов, которые сливались с картой на тёмной теме.
- Добавлен `<meta name="color-scheme">` и `color-scheme` в `:root` — нативные контролы следуют активной теме.
- Явные `color` на лейблах, заголовках, `calc-list`, `calc-note`, `calc-formula`, опциях кастомного селекта — ничего не зависит от наследования.
- Убраны проблемные `opacity:.92` у лейблов и `opacity:.9` у `th`.

### Освежение вида
- Новая акцентная палитра: violet `#8b5cf6` / cyan `#22d3ee` / pink `#f472b6`.
- Мягче aurora и точечная сетка, ярче focus-ring, обновлённые кнопки и stat-карточки.
- `calc-formula` — моноширинная плашка с фиолетовой рамкой, читаемая на обеих темах.
- Светлая тема получила отдельный набор акцентов (`#7c3aed / #0891b2 / #ec4899`) для лучшего контраста на белом.

### Мобильная оптимизация
- В embed-режиме (`.is-embed`) весь хедер раньше скрывался вместе с кнопкой темы. Теперь хедер превращается в фиксированный контейнер в правом верхнем углу, бренд прячется, а кнопка темы остаётся плавающей и доступной из встроенного Bitrix-окна.
- KPI-ряды складываются в одну колонку: label сверху, инпут на всю ширину — вместо зажатого `1fr / 200px`.
- Инпуты и селекты получили `font-size: 16px` — iOS больше не зумит при фокусе.
- Результаты и карточки расчётов — одна колонка, компактнее padding и заголовки.
- Липкая панель кнопок «Рассчитать / Сбросить» растягивается на всю ширину, кнопки `flex:1`, глобальная ошибка переезжает над ними, учтён `safe-area-inset-bottom`.
- Сворачиваемые секции получили шеврон `▾`, который поворачивается при открытии.
- Увеличены touch-target'ы у опций кастомного селекта, тема-тоггла, инпутов нарушений.
- Дополнительный брейкпойнт `≤ 420px` — ещё компактнее для iPhone SE и узких экранов.

Разметка, id, классы и JS-логика не тронуты — изменения только в CSS (+ один `<meta>` и перенос theme-toggle в embed-режиме через стили).

## Test plan

- [ ] Открыть на десктопе в светлой и тёмной теме — проверить контраст и отсутствие «слитых» областей.
- [ ] Переключить тему кнопкой — убедиться, что все тексты остаются читаемыми.
- [ ] Открыть на мобильном устройстве (или в DevTools ≤ 640px): KPI-поля стекаются, инпуты не зумят при фокусе на iOS, липкая панель кнопок работает.
- [ ] Проверить embed-режим (iframe) на Bitrix-странице — кнопка переключения темы должна плавать в правом верхнем углу.
- [ ] Пройти полный сценарий расчёта (ввести данные, нажать «Рассчитать», открыть «Логика расчётов») и убедиться, что значения, формулы и нарушения остались корректными.

https://claude.ai/code/session_01FhPFFzWLk8b2LbZZovSx2w