### PR TITLE
Запретить кэширование HTML калькулятора

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,10 @@
   <meta charset="utf-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <meta name="color-scheme" content="dark" />
+  <!-- Запрещаем кэширование HTML, чтобы пользователи всегда получали актуальную версию калькулятора -->
+  <meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
+  <meta http-equiv="Pragma" content="no-cache" />
+  <meta http-equiv="Expires" content="0" />
   <title>Калькулятор эффективности и лидерства — Neo</title>
   <style>
   /* Во фрейме убираем большую «шапку» и добавляем отступ снизу,


### PR DESCRIPTION
## Контекст

Пользователь сообщил, что для роли «Директор» (БЮ БК и остальные) калькулятор по‑прежнему не даёт сделать расчёт с пустым «баллом индекса команды» и пишет «Заполните все обязательные поля».

## Диагностика

Логика уже исправлена в `main` (PR #14): поле «индекс команды» для роли «Директор» опционально. Я воспроизвёл сценарий через jsdom на актуальном `index.html` из `main`:

```
BU=АЗС role=Директор teamIndex=empty -> missing=0 validateAll=true
BU=МБ  role=Директор teamIndex=empty -> missing=0 validateAll=true
BU=БК  role=Директор teamIndex=empty -> missing=0 validateAll=true
BU=ФК  role=Директор teamIndex=empty -> missing=0 validateAll=true
```

То есть код пропускает расчёт с пустым полем во всех БЮ. Причина жалобы — **устаревшая версия страницы из кэша** (браузер / GitHub Pages CDN).

## Что в этом PR

Добавлены meta‑теги, запрещающие кэширование HTML, чтобы пользователи всегда получали актуальную версию страницы:

```html
<meta http-equiv="Cache-Control" content="no-cache, no-store, must-revalidate" />
<meta http-equiv="Pragma" content="no-cache" />
<meta http-equiv="Expires" content="0" />
```

## Примечание для пользователя

Чтобы увидеть исправление прямо сейчас (до того как этот PR смержится), нужно один раз сделать жёсткое обновление страницы: **Ctrl+Shift+R** (Windows) / **Cmd+Shift+R** (Mac), либо открыть в режиме инкогнито. После этого расчёт для «Директора» с пустым индексом команды будет проходить.

https://claude.ai/code/session_01MtA8gQbYaZncU6Wr996BeE

---
_Generated by [Claude Code](https://claude.ai/code/session_01MtA8gQbYaZncU6Wr996BeE)_